### PR TITLE
fix broken navbar-burger, fixes #36

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -17,19 +17,19 @@
       <!-- Responsive toggle -->
       <div class="navbar-burger" @click="openMobileMenu()">
         <div class="menu-toggle">
-          <span
+          <div
             class="icon-box-toggle"
             :class="{
                       'active': mobileOpen,
                       '': !mobileOpen
                   }"
           >
-            <span class="rotate">
+            <div class="rotate">
               <i class="icon-line-top"></i>
               <i class="icon-line-center"></i>
               <i class="icon-line-bottom"></i>
-            </span>
-          </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/NavbarClone.astro
+++ b/src/components/NavbarClone.astro
@@ -19,19 +19,19 @@
       <!-- Responsive toggle -->
       <div class="navbar-burger" @click="openMobileMenu()">
         <div class="menu-toggle">
-          <span
+          <div
             class="icon-box-toggle"
             :class="{
                       'active': mobileOpen,
                       '': !mobileOpen
                   }"
           >
-            <span class="rotate">
+            <div class="rotate">
               <i class="icon-line-top"></i>
               <i class="icon-line-center"></i>
               <i class="icon-line-bottom"></i>
-            </span>
-          </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/styles/components/_hamburger.scss
+++ b/src/styles/components/_hamburger.scss
@@ -29,23 +29,14 @@ Hamburger menu icon
         width: 30px;
         height: 30px;
 
-        &.active > span.rotate {
-            /*transform*/
-            -webkit-transform: rotate(90deg);
-            -moz-transform: translate(0px, 0px) rotate(90deg);
-            -ms-transform: translate(0px, 0px) rotate(90deg);
-            -o-transform: translate(0px, 0px) rotate(90deg);
-            transform: translate(0px, 0px) rotate(90deg);
-        }
-
-        &.active > span > i.icon-line-center {
+        &.active > div > i.icon-line-center {
             visibility: hidden;
             width: 1px;
             height: 3px;
             left: 70%;
         }
 
-        &.active > span > i.icon-line-bottom {
+        &.active > div > i.icon-line-bottom {
             margin: -2px 0 0 -10px;
             left: 50%;
             top: 12px;
@@ -58,7 +49,7 @@ Hamburger menu icon
             transform: translate(0px, 0px) rotate(135deg);
         }
 
-        &.active > span > i.icon-line-top {
+        &.active > div > i.icon-line-top {
             margin: -2px 0 0 -10px;
             left: 50%;
             top: 12px;


### PR DESCRIPTION
The native bulma css is causing the nav to shift out of place. I updated the burger nav to use divs (same as the shifter theme), to prevent this.

**Broken**:
![krypton-broken](https://github.com/cssninjaStudio/krypton/assets/674809/9a60cfc7-4370-4716-b193-69393b037260)

**Updated:**
![krypton-fixed](https://github.com/cssninjaStudio/krypton/assets/674809/cedb28a3-0842-429b-98ae-2ddefea14a1b)
