### PR TITLE
fix: aligned hamburger menu icon

### DIFF
--- a/src/styles/components/_hamburger.scss
+++ b/src/styles/components/_hamburger.scss
@@ -23,7 +23,7 @@ Hamburger menu icon
         height: 100%;
         width: 100%;
         background: transparent;
-        position: relative;
+        position: absolute;
         top: 3px;
         display: block;
         width: 30px;


### PR DESCRIPTION
I aligned hamburger menu icon

before:
![Screenshot (40)](https://github.com/cssninjaStudio/krypton/assets/112545445/a37585f4-29f3-458d-b9f0-53fbed2f8ada)

after:
![image](https://github.com/cssninjaStudio/krypton/assets/112545445/4542d3d9-8e2b-49b7-9142-4734eb3ae210)

